### PR TITLE
Fix for compiling on newer versions of gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC=gcc
 all:	heatmap
 
 heatmap:	heatmap.c
-	$(CC) -lm -o $@ $<
+	$(CC) -o $@ $< -lm
 
 clean:
 	rm -f heatmap


### PR DESCRIPTION
Compiling on Ubuntu 12.04 I get the following:

```
$ make
gcc -lm -o heatmap heatmap.c
/tmp/cc1kQt5n.o: In function `loglinear_buckets':
heatmap.c:(.text+0x267): undefined reference to `pow'
collect2: ld returned 1 exit status
make: *** [heatmap] Error 1
$ gcc --version
gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
```

This change will resolve the error, and appears to still work on Mac OS X 10.8, Solaris 11.1 and Debian 6, each of which has a gcc version older than 4.6.

My reference for this fix is this [Stack Overflow question](http://stackoverflow.com/questions/12644922/).
